### PR TITLE
Support ESModule natively for config using internal API

### DIFF
--- a/Hammerspoon 2.xcodeproj/project.pbxproj
+++ b/Hammerspoon 2.xcodeproj/project.pbxproj
@@ -11,13 +11,14 @@
 		4F488B302E97E79800A2B5F4 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 4F488B2F2E97E79800A2B5F4 /* Sparkle */; };
 		4F59E3502EFC986100954462 /* hammerspoon.d.ts in Resources */ = {isa = PBXBuildFile; fileRef = 4F59E34F2EFC985500954462 /* hammerspoon.d.ts */; };
 		4F59E3512EFC986100954462 /* api.json in Resources */ = {isa = PBXBuildFile; fileRef = 4F59E34E2EFC984900954462 /* api.json */; };
+		EC3BA53B2F013CE0001291A0 /* InternalESModuleForSwiftJavaScriptCore in Frameworks */ = {isa = PBXBuildFile; productRef = EC3BA53A2F013CE0001291A0 /* InternalESModuleForSwiftJavaScriptCore */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		4F5641912E8333840099EB4C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4F56417B2E8333830099EB4C /* Project object */;
-			proxyType = 1;
+			proxyType = 0;
 			remoteGlobalIDString = 4F5641822E8333830099EB4C;
 			remoteInfo = "Hammerspoon 2";
 		};
@@ -59,6 +60,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EC3BA53B2F013CE0001291A0 /* InternalESModuleForSwiftJavaScriptCore in Frameworks */,
 				4F488B302E97E79800A2B5F4 /* Sparkle in Frameworks */,
 				4F463EA02EA7A669000A2135 /* AXSwift in Frameworks */,
 			);
@@ -151,6 +153,7 @@
 			packageProductDependencies = (
 				4F488B2F2E97E79800A2B5F4 /* Sparkle */,
 				4F463E9F2EA7A669000A2135 /* AXSwift */,
+				EC3BA53A2F013CE0001291A0 /* InternalESModuleForSwiftJavaScriptCore */,
 			);
 			productName = "Hammerspoon 2";
 			productReference = 4F5641832E8333830099EB4C /* Hammerspoon 2.app */;
@@ -210,6 +213,7 @@
 			packageReferences = (
 				4F488B2E2E97E79800A2B5F4 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				4F463E9E2EA7A669000A2135 /* XCRemoteSwiftPackageReference "AXSwift" */,
+				EC3BA5392F013CE0001291A0 /* XCRemoteSwiftPackageReference "InternalESModuleForSwiftJavaScriptCore" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 4F5641842E8333830099EB4C /* Products */;
@@ -261,7 +265,6 @@
 /* Begin PBXTargetDependency section */
 		4F5641922E8333840099EB4C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4F5641822E8333830099EB4C /* Hammerspoon 2 */;
 			targetProxy = 4F5641912E8333840099EB4C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
@@ -576,6 +579,14 @@
 				minimumVersion = 2.8.0;
 			};
 		};
+		EC3BA5392F013CE0001291A0 /* XCRemoteSwiftPackageReference "InternalESModuleForSwiftJavaScriptCore" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ghostflyby/InternalESModuleForSwiftJavaScriptCore";
+			requirement = {
+				kind = exactVersion;
+				version = 1.0.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -588,6 +599,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4F488B2E2E97E79800A2B5F4 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
+		};
+		EC3BA53A2F013CE0001291A0 /* InternalESModuleForSwiftJavaScriptCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EC3BA5392F013CE0001291A0 /* XCRemoteSwiftPackageReference "InternalESModuleForSwiftJavaScriptCore" */;
+			productName = InternalESModuleForSwiftJavaScriptCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Hammerspoon 2.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Hammerspoon 2.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "256b98abbe04f8c9e316276743f01f93ec14b99236d5b3f17e39d22149f507e4",
+  "originHash" : "92e377f70d692204de061c74b38080da0e7cee12e0fa5c74b96aa2d1b8b125f5",
   "pins" : [
     {
       "identity" : "axswift",
@@ -8,6 +8,15 @@
       "state" : {
         "branch" : "main",
         "revision" : "33e7e2fce473c299ea538f3925a48f399faa1be0"
+      }
+    },
+    {
+      "identity" : "internalesmoduleforswiftjavascriptcore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ghostflyby/InternalESModuleForSwiftJavaScriptCore",
+      "state" : {
+        "revision" : "a8a08024acf416b507e541fcfa0b59e8600cdd28",
+        "version" : "1.0.1"
       }
     },
     {

--- a/Hammerspoon 2/Engine/MultiRootFSModuleLoader.swift
+++ b/Hammerspoon 2/Engine/MultiRootFSModuleLoader.swift
@@ -1,0 +1,126 @@
+//
+//  MultiRootFSModuleLoader.swift
+//  Hammerspoon 2
+//
+//  Created by Codex on 28/12/2025.
+//
+
+import Foundation
+import InternalESModuleForSwiftJavaScriptCore
+import JavaScriptCore
+
+@_documentation(visibility: private)
+final class MultiRootFSModuleLoader: ESModuleLoaderDelegate {
+    private let virtualMachine: JSVirtualMachine
+    private var baseRoots: [URL]
+    private var moduleCache: [URL: ESModuleScript] = [:]
+
+    init(virtualMachine: JSVirtualMachine, baseURLs: [URL]) {
+        self.virtualMachine = virtualMachine
+        self.baseRoots = baseURLs.map { $0.standardizedFileURL }
+    }
+
+    func module(for url: URL) throws -> ESModuleScript? {
+        guard let moduleURL = resolveModuleURL(url: url) else {
+            return nil
+        }
+
+        if let cached = moduleCache[moduleURL] {
+            return cached
+        }
+
+        let source = try String(contentsOf: moduleURL, encoding: .utf8)
+        let module = try ESModuleScript(
+            withSource: source,
+            andSourceURL: moduleURL,
+            andBytecodeCache: nil,
+            inVirtualMachine: virtualMachine
+        )
+        moduleCache[moduleURL] = module
+        return module
+    }
+
+    func fetchModule(
+        in context: JSContext,
+        identifier: String,
+        resolve: @escaping (ESModuleScript) -> Void,
+        reject: @escaping (JSValue) -> Void
+    ) {
+        guard let moduleURL = resolveModuleURL(identifier: identifier) else {
+            reject(
+                JSValue(
+                    newErrorFromMessage: "Unable to resolve module identifier: \(identifier)",
+                    in: context))
+            return
+        }
+
+        do {
+            guard let module = try module(for: moduleURL) else {
+                reject(
+                    JSValue(
+                        newErrorFromMessage: "Unable to resolve module URL: \(moduleURL.path)",
+                        in: context))
+                return
+            }
+            resolve(module)
+        } catch {
+            reject(
+                JSValue(
+                    newErrorFromMessage: "Unable to load module \(moduleURL.path): \(error)",
+                    in: context))
+        }
+    }
+
+    private func resolveModuleURL(identifier: String) -> URL? {
+        let candidate: URL
+        if let url = URL(string: identifier), url.scheme != nil {
+            guard url.isFileURL else {
+                return nil
+            }
+            candidate = url
+        } else {
+            let expandedPath = NSString(string: identifier).expandingTildeInPath
+            if expandedPath.hasPrefix("/") {
+                candidate = URL(fileURLWithPath: expandedPath)
+            } else {
+                for root in baseRoots {
+                    let probe = URL(fileURLWithPath: expandedPath, relativeTo: root)
+                        .standardizedFileURL
+                    if isWithinAllowedRoots(probe)
+                        && FileManager.default.fileExists(atPath: probe.path)
+                    {
+                        return probe
+                    }
+                }
+                return nil
+            }
+        }
+
+        let normalized = candidate.standardizedFileURL
+        return isWithinAllowedRoots(normalized) ? normalized : nil
+    }
+
+    private func resolveModuleURL(url: URL) -> URL? {
+        guard url.isFileURL else {
+            return nil
+        }
+        let normalized = url.standardizedFileURL
+        return isWithinAllowedRoots(normalized) ? normalized : nil
+    }
+
+    private func isWithinAllowedRoots(_ url: URL) -> Bool {
+        let path = url.path
+        for root in baseRoots {
+            let rootPath = root.path
+            let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+            if path == rootPath || path.hasPrefix(prefix) {
+                return true
+            }
+        }
+        return false
+    }
+    
+    func willEvaluateModule(at key: URL) {
+        
+    }
+}

--- a/Hammerspoon 2/Protocols/JSEngineProtocol.swift
+++ b/Hammerspoon 2/Protocols/JSEngineProtocol.swift
@@ -18,11 +18,17 @@ protocol JSEngineProtocol {
     /// - Returns: The result of the evaluation, or nil if evaluation fails
     @discardableResult func eval(_ script: String) -> Any?
 
-    /// Evaluates JavaScript from a file URL
+    /// Evaluates JavaScript from a file URL synchronously
     /// - Parameter url: The URL of the JavaScript file to evaluate
     /// - Returns: The result of the evaluation, or nil if evaluation fails
     /// - Throws: HammerspoonError if the file cannot be read or evaluated
     @discardableResult func evalFromURL(_ url: URL) throws -> Any?
+
+    /// Evaluates JavaScript from a file URL asynchronously as an ES module
+    /// - Parameter url: The file URL of the JavaScript file to evaluate
+    /// - Returns: The result of the evaluation, or nil if evaluation fails
+    /// - Throws: HammerspoonError if the file cannot be read or evaluated
+    @discardableResult func evalFromURL(_ url: URL) async throws -> Any?
 
     /// Resets the JavaScript context, creating a fresh environment
     /// - Throws: HammerspoonError if context creation fails

--- a/Hammerspoon 2/Utilities/Exceptions.swift
+++ b/Hammerspoon 2/Utilities/Exceptions.swift
@@ -12,6 +12,7 @@ struct HammerspoonError: Error, Equatable, CustomLocalizedStringResourceConverti
     enum ErrorKind: String {
         case vmCreation = "Creating JS VM"
         case jsEvalURLKind = "Invalid JS URL"
+        case jsModuleEvaluation = "JS Module Evaluation"
         case unknown = "Unknown"
     }
 

--- a/Hammerspoon 2Tests/Mocks/MockJSEngine.swift
+++ b/Hammerspoon 2Tests/Mocks/MockJSEngine.swift
@@ -53,6 +53,15 @@ class MockJSEngine: JSEngineProtocol {
         return result
     }
 
+    @discardableResult func evalFromURL(_ url: URL) async throws -> Any? {
+        if shouldThrowOnEvalFromURL {
+            throw HammerspoonError(.vmCreation, msg: "Mock error: evalFromURL failed")
+        }
+        let result = evalFromURLReturnValue
+        evalFromURLCalls.append((url: url, result: result))
+        return result
+    }
+
     func resetContext() throws {
         if shouldThrowOnReset {
             throw HammerspoonError(.vmCreation, msg: "Mock error: resetContext failed")


### PR DESCRIPTION
## details
- uses JSC internal OBJC APIs to utilize native esmodule support in JSC.
- taking the place of `require`
- introducing a asynchronous `evalFromUrl`

Some tests just fails with nothing to do with my changes.

## demo



https://github.com/user-attachments/assets/87c2d54d-8c8d-496b-96e0-1699a3ea7edc


## future works
unfortunately, the ESModule only supports ones starting with `/`, `./` and `../` according to https://github.com/WebKit/WebKit/blob/8615f506db9162ea73173834af9e4b997d92dd93/Source/JavaScriptCore/API/JSAPIGlobalObject.mm#L94

To support custom schemes or modulemap like features for introducing npm, I'll have to use internal cpp based APIs instead of ObjC-based ones.