### PR TITLE
Fix hs.task shell EOF handler cleanup

### DIFF
--- a/Hammerspoon 2/Modules/hs.task/HSTask.swift
+++ b/Hammerspoon 2/Modules/hs.task/HSTask.swift
@@ -214,6 +214,9 @@ import JavaScriptCoreExtras
                     }
                 }
 
+                self.stdoutPipe?.fileHandleForReading.readabilityHandler = nil
+                self.stderrPipe?.fileHandleForReading.readabilityHandler = nil
+
                 // Unregister task after all callbacks complete
                 self.module?.unregisterActiveTask(self)
             }
@@ -314,7 +317,10 @@ import JavaScriptCoreExtras
             guard let self = self else { return }
 
             let data = handle.availableData
-            guard !data.isEmpty else { return }
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
             guard let output = String(data: data, encoding: .utf8) else { return }
 
             Task { @MainActor [weak self] in
@@ -340,7 +346,10 @@ import JavaScriptCoreExtras
             guard let self = self else { return }
 
             let data = handle.availableData
-            guard !data.isEmpty else { return }
+            guard !data.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
             guard let output = String(data: data, encoding: .utf8) else { return }
 
             Task { @MainActor [weak self] in

--- a/Hammerspoon 2Tests/IntegrationTests/HSTaskIntegrationTests.swift
+++ b/Hammerspoon 2Tests/IntegrationTests/HSTaskIntegrationTests.swift
@@ -671,6 +671,54 @@ import JavaScriptCore
         let success = await harness.waitForAsync(timeout: 2.0) { promiseResolved }
         #expect(success, "Shell command should complete")
         #expect(capturedOutput.contains("Shell command test"), "Should execute shell command")
+        let tasksCompleted = await harness.waitForTasksToComplete(timeout: 2.0)
+        #expect(tasksCompleted, "Shell task should be cleaned up")
+        await harness.cleanup()
+    }
+
+    @Test("hs.task.shell() can run repeatedly without leaving active tasks")
+    func testShellRepeatedCleanup() async {
+        let harness = JSTestHarness()
+        harness.loadModule(HSTaskModule.self, as: "task")
+
+        var promiseResolved = false
+        var count = 0
+        harness.registerCallback("onResolve") { (_: String) in
+            count += 1
+            if count == 3 {
+                promiseResolved = true
+            }
+        }
+
+        harness.eval("""
+        Promise.all([
+            hs.task.shell('printf "one"'),
+            hs.task.shell('printf "two"'),
+            hs.task.shell('printf "three"')
+        ]).then(function(results) {
+            results.forEach(function(result) {
+                onResolve(result.stdout);
+            });
+        });
+        """)
+
+        let success = await harness.waitForAsync(timeout: 2.0) { promiseResolved }
+        #expect(success, "Repeated shell commands should complete")
+        #expect(count == 3, "All shell command results should resolve")
+        let tasksCompleted = await harness.waitForTasksToComplete(timeout: 2.0)
+        #expect(tasksCompleted, "Repeated shell commands should leave no active tasks")
+
+        promiseResolved = false
+        harness.eval("""
+        hs.task.shell('printf "four"').then(function(result) {
+            onResolve(result.stdout);
+        });
+        """)
+
+        let followupSuccess = await harness.waitForAsync(timeout: 2.0) { promiseResolved }
+        #expect(followupSuccess, "Follow-up shell command should complete after cleanup")
+        #expect(count == 4, "Follow-up shell command should also resolve")
+        await harness.cleanup()
     }
 
     @Test("hs.task.parallel() runs tasks concurrently")


### PR DESCRIPTION
## Summary
- clear stdout and stderr readability handlers when the pipe reaches EOF
- clear both handlers again from the termination path so completed tasks cannot keep receiving readability events
- add an integration test that runs hs.task.shell() repeatedly and verifies cleanup completes

## Why
hs.task.shell() goes through runAsync(), which always installs streaming callbacks to collect stdout/stderr for the returned Promise. The Swift side used readabilityHandler to read those pipes, but when availableData returned EOF it just returned without removing the handler. That left the handler active after the pipe closed, which could keep waking the process and spin CPU after hs.task.shell() completed.

## Testing
- xcodebuild test -project "Hammerspoon 2.xcodeproj" -scheme Development -destination "platform=macOS" -derivedDataPath /tmp/Hammerspoon2DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY="" -only-testing:"Hammerspoon 2Tests/HSTaskIntegrationTests/testShell" -only-testing:"Hammerspoon 2Tests/HSTaskIntegrationTests/testShellRepeatedCleanup"
