### PR TITLE
Fix crash on up-arrow with empty console history

### DIFF
--- a/Hammerspoon 2/Windows/ConsoleView.swift
+++ b/Hammerspoon 2/Windows/ConsoleView.swift
@@ -59,6 +59,7 @@ struct ConsoleView: View {
     }
 
     fileprivate func handleUpArrow() -> KeyPress.Result {
+        guard !evalHistory.isEmpty else { return .ignored }
         switch (evalIndex) {
         case -1:
             // Start walking up the history


### PR DESCRIPTION
## Summary

- Add `guard !evalHistory.isEmpty else { return .ignored }` to `handleUpArrow()` in `ConsoleView.swift`
- Without this, pressing up-arrow when no commands have been entered sets `evalIndex` to `-1` (from `count - 1 = 0 - 1`) and then accesses `evalHistory[-1]`, crashing with array index out of range

Partially addresses #43. The other two findings (unused `styleForLogType`, unused `selectedRows`) exist on the `hs2` branch but not on `main`.

## Test plan

- [x] Build succeeds
- No existing unit tests for ConsoleView (SwiftUI view)
- Manual test: launch app, open console, press up-arrow before entering any commands — should no longer crash