### PR TITLE
Switch hs.application watcher to follow hs.ax in having a single addWatcher that causes callbacks to receive all possible events, rather than having to add separate watchers for every desired event

### DIFF
--- a/Hammerspoon 2/Modules/hs.application/HSApplicationModule.swift
+++ b/Hammerspoon 2/Modules/hs.application/HSApplicationModule.swift
@@ -75,21 +75,19 @@ import UniformTypeIdentifiers
 
     /// Create a watcher for application events
     /// - Parameters:
-    ///    - event: The event type to listen for
-    ///    - listener: A javascript function/lambda to call when the event is received. The function will be called with two parameters: the name of the event, and the associated HSApplication object
-    @objc func addWatcher(_ event: String, _ listener: JSValue)
+    ///    - listener: A javascript function/lambda to call when any application event is received. The function will be called with two parameters: the name of the event, and the associated HSApplication object
+    @objc func addWatcher(_ listener: JSValue)
 
     /// Remove a watcher for application events
     /// - Parameters:
-    ///   - event: The event type to stop listening for
-    ///   - listener: The javascript function/lambda that was previously being used to handle the event
-    @objc func removeWatcher(_ event: String, _ listener: JSValue)
+    ///   - listener: The javascript function/lambda that was previously being used to handle events
+    @objc func removeWatcher(_ listener: JSValue)
 
     // NOTE: These are not documented because they are private API for our JavaScript code
     /// SKIP_DOCS
-    @objc(_addWatcher::) func _addWatcher(eventName: String, callback: JSValue)
+    @objc(_addWatcher:) func _addWatcher(callback: JSValue)
     /// SKIP_DOCS
-    @objc(_removeWatcher:) func _removeWatcher(eventName: String)
+    @objc func _removeWatcher()
 
     /// Swift-retained storage for the JS ApplicationModuleWatcherEmitter instance
     /// SKIP_DOCS
@@ -99,15 +97,27 @@ import UniformTypeIdentifiers
 // MARK: - Implementations
 
 class HSApplicationWatcherObject {
-    let eventName: String
     let callback: JSValue
 
-    init(eventName: String, callback: JSValue) {
-        self.eventName = eventName
+    static let notificationToEventName: [NSNotification.Name: String] = [
+        NSWorkspace.willLaunchApplicationNotification: "willLaunch",
+        NSWorkspace.didLaunchApplicationNotification: "didLaunch",
+        NSWorkspace.didTerminateApplicationNotification: "didTerminate",
+        NSWorkspace.didHideApplicationNotification: "didHide",
+        NSWorkspace.didUnhideApplicationNotification: "didUnhide",
+        NSWorkspace.didActivateApplicationNotification: "didActivate",
+        NSWorkspace.didDeactivateApplicationNotification: "didDeactivate",
+    ]
+
+    init(callback: JSValue) {
         self.callback = callback
     }
 
     @objc func handleEvent(notification: NSNotification) {
+        guard let eventName = Self.notificationToEventName[notification.name] else {
+            AKError("hs.application: received unknown notification: \(notification.name)")
+            return
+        }
         let eventApp = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?.asHSApplication()
         callback.call(withArguments: [eventName, eventApp as Any])
     }
@@ -117,7 +127,7 @@ class HSApplicationWatcherObject {
 @MainActor
 @objc class HSApplicationModule: NSObject, HSModuleAPI, HSApplicationModuleAPI {
     var name = "hs.application"
-    private var watchers: [NSNotification.Name:HSApplicationWatcherObject] = [:]
+    private var watcher: HSApplicationWatcherObject? = nil
 
     // Swift-retained storage for the JS-defined ApplicationModuleWatcherEmitter instance
     @objc var _watcherEmitter: JSValue? = nil
@@ -126,11 +136,7 @@ class HSApplicationWatcherObject {
     override required init() { super.init() }
 
     func shutdown() {
-        for eventName in watchers.keys {
-            if let watcherObject = watchers[eventName] {
-                _removeWatcher(eventName: watcherObject.eventName)
-            }
-        }
+        _removeWatcher()
     }
 
     isolated deinit {
@@ -164,73 +170,45 @@ class HSApplicationWatcherObject {
         return NSWorkspace.shared.menuBarOwningApplication?.asHSApplication()
     }
 
-    func eventNameToEvent(eventName: String) -> NSNotification.Name? {
-        var event: NSNotification.Name? = nil
-
-        switch eventName {
-        case "willLaunch":
-            event = NSWorkspace.willLaunchApplicationNotification
-        case "didLaunch":
-            event = NSWorkspace.didLaunchApplicationNotification
-        case "didTerminate":
-            event = NSWorkspace.didTerminateApplicationNotification
-        case "didHide":
-            event = NSWorkspace.didHideApplicationNotification
-        case "didUnhide":
-            event = NSWorkspace.didUnhideApplicationNotification
-        case "didActivate":
-            event = NSWorkspace.didActivateApplicationNotification
-        case "didDeactivate":
-            event = NSWorkspace.didDeactivateApplicationNotification
-        default:
-            AKError("hs.application: unknown watcher event: \(eventName)")
-        }
-
-        return event
+    @objc func addWatcher(_ listener: JSValue) {
+        _watcherEmitter?.invokeMethod("on", withArguments: [listener])
     }
 
-    @objc func addWatcher(_ event: String, _ listener: JSValue) {
-        _watcherEmitter?.invokeMethod("on", withArguments: [event, listener])
+    @objc func removeWatcher(_ listener: JSValue) {
+        _watcherEmitter?.invokeMethod("removeListener", withArguments: [listener])
     }
 
-    @objc func removeWatcher(_ event: String, _ listener: JSValue) {
-        _watcherEmitter?.invokeMethod("removeListener", withArguments: [event, listener])
-    }
-
-    @objc(_addWatcher::) func _addWatcher(eventName: String, callback: JSValue) {
-        guard let event = eventNameToEvent(eventName: eventName) else {
-            AKError("hs.application.addWatcher(): Unknown event name: \(eventName)")
+    @objc(_addWatcher:) func _addWatcher(callback: JSValue) {
+        if watcher != nil {
+            AKWarning("hs.application._addWatcher(): Already watching. Refusing to create a second.")
             return
         }
 
-        if watchers.keys.contains(event) {
-            // No action required, we are already watching for this event
-            AKWarning("hs.application.addWatcher(): There is already a watcher for \(eventName). Refusing to create a second.")
-            return
-        }
-
-        let watcherObject = HSApplicationWatcherObject(eventName: eventName, callback: callback)
-
-        AKTrace("hs.application.addWatcher(): Adding watcher for \(event)")
+        let watcherObject = HSApplicationWatcherObject(callback: callback)
         let selector = #selector(HSApplicationWatcherObject.handleEvent(notification:))
-        NSWorkspace.shared.notificationCenter.addObserver(watcherObject,
-                                                          selector: selector,
-                                                          name: event, object: nil)
 
-        watchers[event] = watcherObject
+        for notificationName in HSApplicationWatcherObject.notificationToEventName.keys {
+            AKTrace("hs.application._addWatcher(): Registering for \(notificationName.rawValue)")
+            NSWorkspace.shared.notificationCenter.addObserver(watcherObject,
+                                                              selector: selector,
+                                                              name: notificationName,
+                                                              object: nil)
+        }
+
+        watcher = watcherObject
     }
 
-    @objc(_removeWatcher:) func _removeWatcher(eventName: String) {
-        guard let event = eventNameToEvent(eventName: eventName) else {
-            AKError("hs.application.removeWatcher(): Unknown event name: \(eventName)")
-            return
+    @objc func _removeWatcher() {
+        guard let watcherObject = watcher else { return }
+
+        for notificationName in HSApplicationWatcherObject.notificationToEventName.keys {
+            NSWorkspace.shared.notificationCenter.removeObserver(watcherObject as Any,
+                                                                 name: notificationName,
+                                                                 object: nil)
         }
 
-        if let watcherObject = watchers[event] {
-            AKTrace("hs.application.removeWatcher: Removing watcher for \(event)")
-            NSWorkspace.shared.notificationCenter.removeObserver(watcherObject as Any, name: event, object: nil)
-            watchers.removeValue(forKey: event)
-        }
+        watcher = nil
+        AKTrace("hs.application._removeWatcher(): Removed all application event watchers")
     }
 
     // MARK: - API for application information

--- a/Hammerspoon 2/Modules/hs.application/hs.application.js
+++ b/Hammerspoon 2/Modules/hs.application/hs.application.js
@@ -7,54 +7,47 @@
 
 "use strict";
 
-// one-to-many event emitter for hs.application events that Swift can only map 1:1.
+// one-to-many event emitter for hs.application events
 class ApplicationModuleWatcherEmitter {
-    #events = {}
+    #listeners = []
 
     constructor() {}
 
     #handleEvent(event, appObject) {
-        if (Array.isArray(this.#events[event] )) {
-            var listeners = this.#events[event].slice();
-            const length = listeners.length;
+        var listeners = this.#listeners.slice();
+        const length = listeners.length;
 
-            for (var i = 0; i < length; i++) {
-                listeners[i].apply(null, [event, appObject]);
-            }
+        for (var i = 0; i < length; i++) {
+            listeners[i].apply(null, [event, appObject]);
         }
     }
 
-    on(event, listener) {
+    on(listener) {
         if (typeof listener !== 'function') {
             throw new Error("hs.application.addWatcher(): The provided handler must be a function")
         }
 
-        if (!Array.isArray(this.#events[event])) {
-            this.#events[event] = [];
-            hs.application._addWatcher(event, (event, appObject) => { this.#handleEvent(event, appObject) });
-        }
-
-        if (this.#events[event].includes(listener)) {
-            console.error("hs.application.addWatcher(): The provided handler for '" + event + "' is already registered.")
+        if (this.#listeners.includes(listener)) {
+            console.error("hs.application.addWatcher(): The provided handler is already registered.")
             return;
         }
 
-        this.#events[event].push(listener);
+        if (this.#listeners.length === 0) {
+            hs.application._addWatcher((event, appObject) => { this.#handleEvent(event, appObject) });
+        }
+
+        this.#listeners.push(listener);
     }
 
-    removeListener(event, listener) {
-        var idx;
+    removeListener(listener) {
+        const idx = this.#listeners.indexOf(listener);
 
-        if (Array.isArray(this.#events[event])) {
-            idx = this.#events[event].indexOf(listener);
+        if (idx > -1) {
+            this.#listeners.splice(idx, 1);
+        }
 
-            if (idx > -1) {
-                this.#events[event].splice(idx, 1);
-            }
-
-            if (this.#events[event].length == 0) {
-                hs.application._removeWatcher(event);
-            }
+        if (this.#listeners.length === 0) {
+            hs.application._removeWatcher();
         }
     }
 }

--- a/Hammerspoon 2Tests/IntegrationTests/HSApplicationIntegrationTests.swift
+++ b/Hammerspoon 2Tests/IntegrationTests/HSApplicationIntegrationTests.swift
@@ -8,6 +8,7 @@
 import Testing
 import JavaScriptCore
 @testable import Hammerspoon_2
+import AppKit
 
 /// Integration tests for hs.application module
 ///
@@ -16,6 +17,7 @@ import JavaScriptCore
 ///
 /// Note: These tests interact with real running applications on the system.
 @MainActor
+@Suite("hs.application main tests")
 struct HSApplicationIntegrationTests {
 
     // MARK: - Module API Tests
@@ -369,5 +371,396 @@ struct HSApplicationIntegrationTests {
         harness.expectTrue("Array.isArray(appNames)")
         harness.expectTrue("appNames.length > 0")
         harness.expectTrue("appNames.indexOf('Finder') !== -1")
+    }
+}
+
+// MARK: - Watcher Structure Tests
+
+/// Tests the watcher API surface and lifecycle mechanics — no application events need to fire.
+@Suite("hs.application watcher structure tests")
+struct HSApplicationWatcherStructureTests {
+
+    private func makeHarness() -> JSTestHarness {
+        let harness = JSTestHarness()
+        harness.loadModule(HSApplicationModule.self, as: "application")
+        return harness
+    }
+
+    @Test("addWatcher is a function")
+    func testAddWatcherIsFunction() {
+        let harness = makeHarness()
+        harness.expectTrue("typeof hs.application.addWatcher === 'function'")
+    }
+
+    @Test("removeWatcher is a function")
+    func testRemoveWatcherIsFunction() {
+        let harness = makeHarness()
+        harness.expectTrue("typeof hs.application.removeWatcher === 'function'")
+    }
+
+    @Test("_watcherEmitter is initialized by hs.application.js")
+    func testWatcherEmitterInitialized() {
+        let harness = makeHarness()
+        harness.expectTrue("hs.application._watcherEmitter !== null && hs.application._watcherEmitter !== undefined")
+    }
+
+    @Test("addWatcher throws when listener is a string")
+    func testAddWatcherThrowsForString() {
+        let harness = makeHarness()
+        harness.eval("hs.application.addWatcher('not a function')")
+        #expect(harness.hasException)
+    }
+
+    @Test("addWatcher throws when listener is a number")
+    func testAddWatcherThrowsForNumber() {
+        let harness = makeHarness()
+        harness.eval("hs.application.addWatcher(42)")
+        #expect(harness.hasException)
+    }
+
+    @Test("addWatcher throws when listener is null")
+    func testAddWatcherThrowsForNull() {
+        let harness = makeHarness()
+        harness.eval("hs.application.addWatcher(null)")
+        #expect(harness.hasException)
+    }
+
+    @Test("addWatcher and removeWatcher cycle completes without error")
+    func testAddRemoveCycleIsSafe() {
+        let harness = makeHarness()
+        harness.eval("""
+            var _ws1Fn = function(event, app) {};
+            hs.application.addWatcher(_ws1Fn);
+            hs.application.removeWatcher(_ws1Fn);
+        """)
+        #expect(!harness.hasException)
+    }
+
+    @Test("adding the same listener twice is idempotent")
+    func testAddSameListenerTwiceIsIdempotent() {
+        let harness = makeHarness()
+        harness.eval("""
+            var _ws2Fn = function(event, app) {};
+            hs.application.addWatcher(_ws2Fn);
+            hs.application.addWatcher(_ws2Fn);
+            hs.application.removeWatcher(_ws2Fn);
+        """)
+        #expect(!harness.hasException)
+    }
+
+    @Test("three distinct listeners can be added and removed")
+    func testMultipleDistinctListeners() {
+        let harness = makeHarness()
+        harness.eval("""
+            var _ws3Fn1 = function(event, app) {};
+            var _ws3Fn2 = function(event, app) {};
+            var _ws3Fn3 = function(event, app) {};
+            hs.application.addWatcher(_ws3Fn1);
+            hs.application.addWatcher(_ws3Fn2);
+            hs.application.addWatcher(_ws3Fn3);
+            hs.application.removeWatcher(_ws3Fn1);
+            hs.application.removeWatcher(_ws3Fn2);
+            hs.application.removeWatcher(_ws3Fn3);
+        """)
+        #expect(!harness.hasException)
+    }
+
+    @Test("removeWatcher with an unregistered listener does not throw")
+    func testRemoveUnregisteredListenerIsSafe() {
+        let harness = makeHarness()
+        harness.eval("hs.application.removeWatcher(function(event, app) {})")
+        #expect(!harness.hasException)
+    }
+
+    @Test("removing one of two listeners leaves the other in place")
+    func testRemovingOneListenerLeavesOtherIntact() {
+        let harness = makeHarness()
+        harness.eval("""
+            var _ws4Fn1 = function(event, app) {};
+            var _ws4Fn2 = function(event, app) {};
+            hs.application.addWatcher(_ws4Fn1);
+            hs.application.addWatcher(_ws4Fn2);
+            hs.application.removeWatcher(_ws4Fn1);
+            hs.application.removeWatcher(_ws4Fn2);
+        """)
+        #expect(!harness.hasException)
+    }
+}
+
+// MARK: - Watcher Event Delivery Tests
+
+private nonisolated func chessIsAvailable() -> Bool {
+    NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.Chess") != nil
+}
+
+/// Tests that NSWorkspace application events are correctly delivered to JavaScript watcher callbacks.
+/// Uses Chess.app as the target because it is a bundled macOS app with no side effects.
+@Suite("hs.application watcher event delivery tests", .serialized, .disabled(if: !chessIsAvailable(), "Chess.app not found on this system"))
+struct HSApplicationWatcherEventTests {
+
+    private func makeHarness() -> JSTestHarness {
+        let harness = JSTestHarness()
+        harness.loadModule(HSApplicationModule.self, as: "application")
+        return harness
+    }
+
+    private func launchChess() async -> NSRunningApplication? {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.apple.Chess") else { return nil }
+        return try? await NSWorkspace.shared.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
+    }
+
+    private func terminateAllChess() {
+        NSWorkspace.shared.runningApplications
+            .filter { $0.bundleIdentifier == "com.apple.Chess" }
+            .forEach { $0.terminate() }
+    }
+
+    private func waitForChessToTerminate() async {
+        let deadline = Date().addingTimeInterval(5.0)
+        while Date() < deadline {
+            let stillRunning = NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == "com.apple.Chess" }
+            if !stillRunning { return }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+    }
+
+    // MARK: - Event delivery
+
+    @Test("watcher receives didLaunch when Chess is launched")
+    func testDidLaunch() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _dlEvents = [];
+            var _dlFn = function(event, app) { _dlEvents.push(event); };
+            hs.application.addWatcher(_dlFn);
+        """)
+        defer {
+            harness.eval("hs.application.removeWatcher(_dlFn)")
+            terminateAllChess()
+        }
+
+        guard await launchChess() != nil else { return }
+
+        let received = await harness.waitForAsync(timeout: 5.0) {
+            harness.eval("_dlEvents.indexOf('didLaunch') !== -1") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_dlEvents.indexOf('didLaunch') !== -1")
+        }
+    }
+
+    @Test("watcher receives didHide when Chess is hidden")
+    func testDidHide() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        guard let chess = await launchChess() else { return }
+        // Wait for Chess to finish launching before hiding it
+        try? await Task.sleep(for: .milliseconds(1500))
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _dhEvents = [];
+            var _dhFn = function(event, app) { _dhEvents.push(event); };
+            hs.application.addWatcher(_dhFn);
+        """)
+        defer {
+            harness.eval("hs.application.removeWatcher(_dhFn)")
+            terminateAllChess()
+        }
+
+        chess.hide()
+
+        let received = await harness.waitForAsync(timeout: 3.0) {
+            harness.eval("_dhEvents.indexOf('didHide') !== -1") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_dhEvents.indexOf('didHide') !== -1")
+        }
+    }
+
+    @Test("watcher receives didUnhide when Chess is unhidden")
+    func testDidUnhide() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        guard let chess = await launchChess() else { return }
+        try? await Task.sleep(for: .milliseconds(1500))
+        chess.hide()
+        try? await Task.sleep(for: .milliseconds(500))
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _duEvents = [];
+            var _duFn = function(event, app) { _duEvents.push(event); };
+            hs.application.addWatcher(_duFn);
+        """)
+        defer {
+            harness.eval("hs.application.removeWatcher(_duFn)")
+            terminateAllChess()
+        }
+
+        chess.unhide()
+
+        let received = await harness.waitForAsync(timeout: 3.0) {
+            harness.eval("_duEvents.indexOf('didUnhide') !== -1") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_duEvents.indexOf('didUnhide') !== -1")
+        }
+    }
+
+    @Test("watcher receives didTerminate when Chess is terminated")
+    func testDidTerminate() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        guard let chess = await launchChess() else { return }
+        try? await Task.sleep(for: .milliseconds(1500))
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _dtEvents = [];
+            var _dtFn = function(event, app) { _dtEvents.push(event); };
+            hs.application.addWatcher(_dtFn);
+        """)
+        defer { harness.eval("hs.application.removeWatcher(_dtFn)") }
+
+        chess.terminate()
+
+        let received = await harness.waitForAsync(timeout: 5.0) {
+            harness.eval("_dtEvents.indexOf('didTerminate') !== -1") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_dtEvents.indexOf('didTerminate') !== -1")
+        }
+    }
+
+    // MARK: - Callback argument shape
+
+    @Test("callback receives a string event name and an application object")
+    func testCallbackArguments() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _caEventName = null, _caApp = null;
+            var _caFn = function(event, app) {
+                if (_caEventName === null) { _caEventName = event; _caApp = app; }
+            };
+            hs.application.addWatcher(_caFn);
+        """)
+        defer {
+            harness.eval("hs.application.removeWatcher(_caFn)")
+            terminateAllChess()
+        }
+
+        guard await launchChess() != nil else { return }
+
+        let received = await harness.waitForAsync(timeout: 5.0) {
+            harness.eval("_caEventName !== null") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("typeof _caEventName === 'string' && _caEventName.length > 0")
+            harness.expectTrue("_caApp !== null && typeof _caApp === 'object'")
+        }
+    }
+
+    // MARK: - Multiple listeners
+
+    @Test("multiple listeners all receive the didLaunch event")
+    func testMultipleListenersAllReceiveEvent() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _ml1Count = 0, _ml2Count = 0;
+            var _ml1Fn = function(event, app) { if (event === 'didLaunch') _ml1Count++; };
+            var _ml2Fn = function(event, app) { if (event === 'didLaunch') _ml2Count++; };
+            hs.application.addWatcher(_ml1Fn);
+            hs.application.addWatcher(_ml2Fn);
+        """)
+        defer {
+            harness.eval("""
+                hs.application.removeWatcher(_ml1Fn);
+                hs.application.removeWatcher(_ml2Fn);
+            """)
+            terminateAllChess()
+        }
+
+        guard await launchChess() != nil else { return }
+
+        let received = await harness.waitForAsync(timeout: 5.0) {
+            harness.eval("_ml1Count > 0 && _ml2Count > 0") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_ml1Count > 0")
+            harness.expectTrue("_ml2Count > 0")
+        }
+    }
+
+    @Test("a removed listener does not receive subsequent events")
+    func testRemovedListenerDoesNotReceiveEvents() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _rlRemovedCount = 0, _rlKeptCount = 0;
+            var _rlRemovedFn = function(event, app) { _rlRemovedCount++; };
+            var _rlKeptFn = function(event, app) { if (event === 'didLaunch') _rlKeptCount++; };
+            hs.application.addWatcher(_rlRemovedFn);
+            hs.application.addWatcher(_rlKeptFn);
+            hs.application.removeWatcher(_rlRemovedFn);
+        """)
+        defer {
+            harness.eval("hs.application.removeWatcher(_rlKeptFn)")
+            terminateAllChess()
+        }
+
+        guard await launchChess() != nil else { return }
+
+        let received = await harness.waitForAsync(timeout: 5.0) {
+            harness.eval("_rlKeptCount > 0") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_rlKeptCount > 0")
+            harness.expectEqual("_rlRemovedCount", 0)
+        }
+    }
+
+    // MARK: - Filtering
+
+    @Test("callback can filter events by name using a switch on the event string")
+    func testCallbackCanFilterByEventName() async {
+        terminateAllChess()
+        await waitForChessToTerminate()
+
+        let harness = makeHarness()
+        harness.eval("""
+            var _cfLaunchCount = 0, _cfOtherCount = 0;
+            var _cfFn = function(event, app) {
+                if (event === 'didLaunch') { _cfLaunchCount++; } else { _cfOtherCount++; }
+            };
+            hs.application.addWatcher(_cfFn);
+        """)
+        defer {
+            harness.eval("hs.application.removeWatcher(_cfFn)")
+            terminateAllChess()
+        }
+
+        guard await launchChess() != nil else { return }
+
+        let received = await harness.waitForAsync(timeout: 5.0) {
+            harness.eval("_cfLaunchCount > 0") as? Bool == true
+        }
+        if received {
+            harness.expectTrue("_cfLaunchCount > 0")
+        }
     }
 }


### PR DESCRIPTION
Closes #48
