### PR TITLE
Fix HSWindow id initialization

### DIFF
--- a/Hammerspoon 2/Modules/hs.window/HSWindow.swift
+++ b/Hammerspoon 2/Modules/hs.window/HSWindow.swift
@@ -218,6 +218,7 @@ let _AXUIElementGetWindow = unsafe unsafeBitCast(dlsym(dlopen(nil, RTLD_LAZY), "
         if let _AXUIElementGetWindow = unsafe _AXUIElementGetWindow {
             _ = unsafe _AXUIElementGetWindow(element.element, &winId)
         }
+        self.id = Int(winId)
 
         super.init()
     }


### PR DESCRIPTION
## Summary
- Assign HSWindow.id from the underlying CGWindowID during initialization

## Tests
- npm run docs:test
- xcodebuild -project "Hammerspoon 2.xcodeproj" -scheme Development -configuration Debug CODE_SIGNING_ALLOWED=NO build