### PR TITLE
Apply dock menu behaviour on URL and app re-opening events. Closes #121

### DIFF
--- a/Hammerspoon 2/Lifecycle/Hammerspoon_2App.swift
+++ b/Hammerspoon 2/Lifecycle/Hammerspoon_2App.swift
@@ -29,6 +29,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         for url in urls {
             URLEventDispatcher.shared.dispatch(url)
         }
+        NSApp.setActivationPolicy(SettingsManager.shared.dockMenuBehaviour.activationPolicy)
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        NSApp.setActivationPolicy(SettingsManager.shared.dockMenuBehaviour.activationPolicy)
+        return true
     }
 }
 


### PR DESCRIPTION
HS2 applies the dockMenuBehaviour activation policy in `Hammerspoon_2App.swift:87`. It covers two entry points: launch and changing settings.

But two other entry points exist: URL open and app re-open events. Both are reachable from HS2 API:

```js
hs.openConsole()
// or
hs.application.launchOrFocus("net.tenshu.Hammerspoon-2")
```

This fix adds same `setActivationPolicy` call for the latter entry points to make all four of them behave the same way.

Claude helped a lot with reading Swift and understanding apple events.