### PR TITLE
init.js: improve the first default impression 

### DIFF
--- a/DefaultConfig/init.js
+++ b/DefaultConfig/init.js
@@ -5,12 +5,19 @@
 //
 // Full API documentation: https://cmsj.github.io/Hammerspoon2
 // You can also browse it locally at any time with: hs.docs.show()
+//
+// See also:
+// - https://cmsj.github.io/Hammerspoon2/main/js/getting-started.html
+// - https://cmsj.github.io/Hammerspoon2/main/js/migration-guide.html
 
 hs.notify.show("Hammerspoon 2", "Config loaded successfully.")
 
 // Example: bind cmd+alt+h to show a notification.
 // Uncomment the lines below and reload your config to try it out.
 //
-// hs.hotkey.bind(["cmd", "alt"], "h", () => {
+// const helloHotkey = hs.hotkey.bind(["cmd", "alt"], "h", () => {
 //   hs.notify.show("Hammerspoon 2", "Hello from your config!")
 // })
+//
+// Note: capture the return value in a variable that lives as long as your config
+//       does, otherwise it will simply stop firing after the next garbage collection.


### PR DESCRIPTION
Improve the first default init.js, don't show an antipattern as sample hotkey