### PR TITLE
Mirror menu bar extra actions in app menu

### DIFF
--- a/Hammerspoon 2/Lifecycle/Hammerspoon_2App.swift
+++ b/Hammerspoon 2/Lifecycle/Hammerspoon_2App.swift
@@ -166,6 +166,19 @@ struct Hammerspoon_2App: App {
                 Button("About Hammerspoon 2") {
                     openWindow(id: "about")
                 }
+
+                CheckForUpdatesView(updater: updaterController.updater)
+            }
+
+            CommandMenu("Debug") {
+                Button("Reload Config") {
+                    try? ManagerManager.shared.reload()
+                }
+
+                Button("Open Console") {
+                    NSApplication.shared.activate(ignoringOtherApps: true)
+                    openWindow(id: "console")
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

This mirrors the menu bar extra actions in the regular app menu.

`Check for Updates...` is now available from the app menu near the standard app-level items, and the debug actions are available under a new `Debug` menu:

- `Reload Config`
- `Open Console`

## Why

Hammerspoon 2 can be configured with:

- `Show in: Dock only`
- `Show in: Menu bar only`
- `Show in: Dock and Menu bar`

When `Dock only` is selected, the menu bar extra is not visible, so these actions are otherwise not reachable from the menu bar extra.

When `Dock and Menu bar` is selected, the actions are available through the menu bar extra, but on MacBooks with a notch the menu bar can run out of space, making some menu bar extras inaccessible.

Mirroring these actions in the regular app menu keeps them reachable whenever the app menu is available.

## Screenshots

<img width="308" height="283" alt="Bildschirmfoto 2026-09-03 um 01 00 01" src="https://github.com/user-attachments/assets/dd797c36-608c-4990-9108-eb4c369a08c4" /><br>
<img width="150" height="97" alt="Bildschirmfoto 2026-09-03 um 01 00 31" src="https://github.com/user-attachments/assets/bcc1acb9-75c4-44a9-af8a-f54b8a1c050c" />

