### PR TITLE
Fix per-camera addWatcher() for hot-plugged cameras

### DIFF
--- a/Hammerspoon 2/Modules/hs.camera/HSCamera.swift
+++ b/Hammerspoon 2/Modules/hs.camera/HSCamera.swift
@@ -170,9 +170,11 @@ private class CameraCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
     }
 
     let device: AVCaptureDevice
+    weak var cameraModule: HSCameraModule?
 
-    init(device: AVCaptureDevice) {
+    init(device: AVCaptureDevice, cameraModule: HSCameraModule) {
         self.device = device
+        self.cameraModule = cameraModule
         super.init()
     }
 
@@ -213,17 +215,37 @@ private class CameraCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
 
     @objc func addWatcher(_ listener: JSFunction) {
         // invokeMethod doesn't propagate JS exceptions to the calling context's try-catch,
-        // so we validate here and throw via context.exception before delegating.
+        // so validate the listener and emitter before delegating.
         guard let ctx = JSContext.current() else { return }
         guard listener.isObject else {
             ctx.exception = JSValue(newErrorFromMessage: "hs.camera device.addWatcher(): listener must be a function", in: ctx)
             return
         }
-        if _watcherEmitter == nil {
-            let cameraModule = ctx.objectForKeyedSubscript("hs")?.objectForKeyedSubscript("camera")
-            _watcherEmitter = cameraModule?.invokeMethod("_makeCameraEmitter", withArguments: [self])
+        // A previously stored `undefined` emitter must not block a later retry, so
+        // treat any non-object value as absent.
+        if let stored = _watcherEmitter, stored.isUndefined || stored.isNull {
+            _watcherEmitter = nil
         }
-        _watcherEmitter?.invokeMethod("on", withArguments: [listener])
+        if _watcherEmitter == nil {
+            guard let emitterFactory = cameraModule?._makeCameraEmitter,
+                  emitterFactory.isObject else {
+                ctx.exception = JSValue(
+                    newErrorFromMessage: "hs.camera device.addWatcher(): camera watcher emitter factory is unavailable",
+                    in: ctx
+                )
+                return
+            }
+            let emitter = emitterFactory.call(withArguments: [self])
+            _watcherEmitter = (emitter?.isObject == true) ? emitter : nil
+        }
+        guard let emitter = _watcherEmitter else {
+            ctx.exception = JSValue(
+                newErrorFromMessage: "hs.camera device.addWatcher(): failed to create camera watcher emitter",
+                in: ctx
+            )
+            return
+        }
+        emitter.invokeMethod("on", withArguments: [listener])
     }
 
     @objc func removeWatcher(_ listener: JSFunction) {

--- a/Hammerspoon 2/Modules/hs.camera/HSCameraModule.swift
+++ b/Hammerspoon 2/Modules/hs.camera/HSCameraModule.swift
@@ -114,6 +114,8 @@ import AVFoundation
     @objc func _removeWatcher()
     /// SKIP_DOCS
     @objc var _watcherEmitter: JSFunction? { get set }
+    /// SKIP_DOCS
+    @objc var _makeCameraEmitter: JSFunction? { get set }
 }
 
 // MARK: - Implementation
@@ -141,6 +143,7 @@ import AVFoundation
         }
         cameraCache.removeAll()
         _watcherEmitter = nil
+        _makeCameraEmitter = nil
     }
 
     isolated deinit {
@@ -182,7 +185,7 @@ import AVFoundation
 
     private func camera(for device: AVCaptureDevice) -> HSCamera {
         if let cached = cameraCache[device.uniqueID] { return cached }
-        let cam = HSCamera(device: device)
+        let cam = HSCamera(device: device, cameraModule: self)
         cameraCache[device.uniqueID] = cam
         return cam
     }
@@ -190,6 +193,7 @@ import AVFoundation
     // MARK: - Module-level watcher
 
     @objc var _watcherEmitter: JSFunction? = nil
+    @objc var _makeCameraEmitter: JSFunction? = nil
     private var moduleCallback: JSFunction? = nil
 
     @objc func addWatcher(_ listener: JSFunction) {

--- a/Hammerspoon 2Tests/IntegrationTests/HSCameraIntegrationTests.swift
+++ b/Hammerspoon 2Tests/IntegrationTests/HSCameraIntegrationTests.swift
@@ -75,6 +75,19 @@ struct HSCameraTests {
             #expect(harness.evalTypeOf("hs.camera.removeWatcher") == "function")
         }
 
+        @Test("hs.camera.js emitter factory is stored in a Swift-retained property")
+        func testCameraEmitterFactoryIsRetainedBySwift() {
+            let harness = makeHarness()
+            #expect(harness.evalTypeOf("hs.camera._makeCameraEmitter") == "function")
+
+            // The factory must land in the native `_makeCameraEmitter` property rather than
+            // in a JS expando on the module wrapper, which JavaScriptCore may discard once
+            // the wrapper is collected — leaving per-camera addWatcher() with no factory.
+            let module = harness.evalValue("hs.camera")?.toObjectOf(HSCameraModule.self) as? HSCameraModule
+            #expect(module != nil)
+            #expect(module?._makeCameraEmitter?.isObject == true)
+        }
+
         @Test("module-level addWatcher() / removeWatcher() cycle is safe")
         func testModuleWatcherCycle() {
             let harness = makeHarness()


### PR DESCRIPTION
## Summary

`HSCamera.addWatcher()` throws a `TypeError` for cameras that appear after launch (Continuity Camera in particular for me, but probably USB capture devices too?) so the per-camera in-use watcher is never registered.

I think there are two causes (confirmed with Claude):

1. `hs.camera.js` assigns `_makeCameraEmitter` onto the `hs.camera` module object, but it is not declared in `HSCameraModuleAPI`. Like in #191, a JS value stored on a `JSExport` wrapper is not retained by Swift and can go out of scope.
2. `HSCamera.addWatcher()` re-resolves `hs.camera` via `JSContext.current().objectForKeyedSubscript(...)` and then calls `invokeMethod` on the result. When that lookup yields JS `undefined`, Swift optional chaining does not short-circuit (`undefined` is a non-nil `JSValue`), so both `_makeCameraEmitter` and the subsequent `on` call throw — which matches the two identical exceptions per attach in the log below. `_addWatcher()` is never reached, so no CoreMediaIO listener is installed.

Since `addWatcher()` returns `void` and `invokeMethod` exceptions do not propagate to the caller's `try/catch`, the failure is silent to config code: the call appears to succeed, but in-use events never arrive.

## Changes

- Declare `_makeCameraEmitter` in `HSCameraModuleAPI` and back it with a Swift-retained property, so `hs.camera.js` writes into native storage.
- Nil it in `shutdown()`, alongside `_watcherEmitter`.
- Give `HSCamera` a weak reference to its owning module and call the retained factory directly, instead of re-resolving `hs.camera` from inside an AVFoundation hot-plug notification.
- Validate the factory and the constructed emitter, and report failures via `ctx.exception` with distinct messages instead of throwing anonymously.
- Clear a stored non-object emitter so a failed attach doesn't block retries.

## Before

Logs from release build 1.2.x, iPhone Continuity Camera connecting:

 ```
 [camera] connected: Cam Phone Camera
 Error: JavaScript Exception: TypeError: undefined is not an object (evaluating 'cam.addWatcher(handleCameraState)')
 Error: JavaScript Exception: TypeError: undefined is not an object (evaluating 'cam.addWatcher(handleCameraState)')
 [camera] In-use watcher attached to: Cam Phone Camera
 ```

No `hs.camera._addWatcher(): Started watching ...` line, and no in-use callback ever fires.

## After

With the same hardware, patched build, attaching synchronously inside the `connected` event:


 ```
 connected: Cam Phone Camera
 findByName -> found, typeof addWatcher=function
 synchronous addWatcher returned without throwing
 native in-use callback true      <- FaceTime opened
 native in-use callback false     <- FaceTime closed

 ```

No exceptions, and the CoreMediaIO listener delivers in-use transitions.

## Testing

- `Hammerspoon 2Tests/HSCameraTests`: 28 passed, 0 failed (`captureImage` tests skipped, no camera permission in the runner).
- Added a test asserting the factory reaches the native property. It does not reproduce the wrapper-loss itself: in `JSTestHarness` the module is stored as a JS property of `hs`, so its wrapper (and any expando on it) survives forced GC — unlike the real app, where `hs.camera` is a native getter on `ModuleRoot`. I tried a `delete hs.camera` + `JSSynchronousGarbageCollectForDebugging` test first; it passed unpatched, so I dropped it rather than ship a test that can't fail.
- Manually verified on real hardware: iPhone Continuity Camera connect → use in FaceTime → release → disconnect.

No docs regeneration expected; both new protocol members are `SKIP_DOCS`. Sorry for the weird/obscure issue 😄 

## AI disclosure

Written with Claude Code assistance for the log analysis, patch drafting, and test runs. I reviewed and validated every change, ran the test suite, and performed the live Continuity Camera verification myself.