### PR TITLE
hs.hotkey: guard bind() against a callback-less no-op hotkey

### DIFF
--- a/Hammerspoon 2/Modules/hs.hotkey/HSHotkeyModule.swift
+++ b/Hammerspoon 2/Modules/hs.hotkey/HSHotkeyModule.swift
@@ -20,7 +20,7 @@ import Carbon
     ///   - callbackPressed: {(() => void) | null} A JavaScript function to call when the hotkey is pressed, or null for no callback
     ///   - callbackReleased: {(() => void) | null} A JavaScript function to call when the hotkey is released, or null for no callback
     ///   - callbackRepeat?: {(() => void) | null} A JavaScript function to call repeatedly while the hotkey is held down, or null/omitted for no repeat
-    /// - Returns: A hotkey object, or null if binding failed
+    /// - Returns: A hotkey object, or null if binding failed (including when none of the callbacks is a function — at least one is required)
     /// - Example:
     /// ```js
     /// hs.hotkey.bind(["cmd","shift"], "h", () => {
@@ -185,6 +185,14 @@ import Carbon
     // MARK: - Hotkey binding
 
     @objc func bind(_ mods: [String], _ key: String, _ callbackPressed: JSFunction, _ callbackReleased: JSFunction, _ callbackRepeat: JSFunction) -> HSHotkey? {
+        // bind() enables the hotkey immediately, so a hotkey with no callbacks at all would
+        // silently claim the key combination and do nothing. Require at least one callback.
+        // (create() stays permissive so callers can build a hotkey and assign callbacks later.)
+        guard callbackPressed.isFunction || callbackReleased.isFunction || callbackRepeat.isFunction else {
+            AKError("hs.hotkey.bind: at least one of callbackPressed, callbackReleased, or callbackRepeat must be a function")
+            return nil
+        }
+
         guard let hotkey = create(mods, key, callbackPressed, callbackReleased, callbackRepeat) else { return nil }
 
         guard hotkey.enable() else {

--- a/Hammerspoon 2Tests/IntegrationTests/HSHotkeyIntegrationTests.swift
+++ b/Hammerspoon 2Tests/IntegrationTests/HSHotkeyIntegrationTests.swift
@@ -197,7 +197,7 @@ struct HSHotkeyTests {
         @Test("bindSpec sets the message property on the returned hotkey")
         func testBindSpecSetsMessage() {
             let harness = makeHarness()
-            harness.eval("var hk = hs.hotkey.bindSpec({mods: ['ctrl'], key: '9', message: 'test message'})")
+            harness.eval("var hk = hs.hotkey.bindSpec({mods: ['ctrl'], key: '9', message: 'test message', pressed: () => {}})")
             harness.expectTrue("hk.message === 'test message'")
             #expect(!harness.hasException)
         }
@@ -205,7 +205,7 @@ struct HSHotkeyTests {
         @Test("bindSpec without a message leaves message unset")
         func testBindSpecWithoutMessage() {
             let harness = makeHarness()
-            harness.eval("var hk = hs.hotkey.bindSpec({mods: ['ctrl'], key: '0'})")
+            harness.eval("var hk = hs.hotkey.bindSpec({mods: ['ctrl'], key: '0', pressed: () => {}})")
             harness.expectTrue("hk.message === null || hk.message === undefined")
             #expect(!harness.hasException)
         }
@@ -417,6 +417,22 @@ struct HSHotkeyTests {
             let harness = makeHarness()
             harness.eval("var hk = hs.hotkey.bind(['ctrl'], 'a', () => {}, null)")
             harness.expectTrue("hs.hotkey.systemAssigned(['ctrl'], 'a') === null || hs.hotkey.systemAssigned(['ctrl'], 'a') === undefined")
+            #expect(!harness.hasException)
+        }
+
+        @Test("bind with no function callbacks returns null (at least one is required)")
+        func testBindRequiresAtLeastOneFunction() {
+            let harness = makeHarness()
+            harness.eval("var hk = hs.hotkey.bind(['ctrl'], 'n', null, null)")
+            harness.expectTrue("hk === null || hk === undefined")
+            #expect(!harness.hasException)
+        }
+
+        @Test("create with no callbacks still succeeds (deferred assignment)")
+        func testCreateWithoutCallbacksSucceeds() {
+            let harness = makeHarness()
+            harness.eval("var hk = hs.hotkey.create(['ctrl'], 'n', null, null)")
+            harness.expectTrue("typeof hk === 'object' && hk !== null")
             #expect(!harness.hasException)
         }
     }


### PR DESCRIPTION
## Context / question
While reading through `hs.hotkey` I noticed that `bind()` happily creates and
*enables* a hotkey even when no function callback is given at all — e.g.
`bind(mods, key, null, null)` or `bind(mods, key, null, null, null)`. Since `bind()` enables immediately, the result is a hotkey that claims the key combination
(swallowing it from other apps) but runs nothing — a silent no-op.

I'm genuinely **not sure whether that's intended** or just an edge case that never came up. Guarding against it in `bind()` seemed sensible, but I may well be missing a reason it's allowed — **I'm completely fine if this PR is dismissed and rejected.**

## What this PR does
`bind()` returns `null` (and logs an error) unless at least one of them is a function: 
- `callbackPressed`,
- `callbackReleased`, or 
- `callbackRepeat` 


`create()` is deliberately left permissive, so the "build now, assign callbacks later via properties" pattern still works.

(Side note: the `message` toast is shown just before a callback fires, so a
message-only hotkey never shows its message either — which is partly why a
callback-less hotkey feels like a mistake rather than a use case.)

## Example
```js
console.log("before")
var cmdAltH = hs.hotkey.bind(["cmd", "alt"], "h", null, null)
console.log("after")
```

Log:
```
2026-09-07 02:02:33 - JavaScript: before
2026-09-07 02:02:33 - Debug: Loading module: hotkey
2026-09-07 02:02:33 - Garbage: Init of hs.hotkey: 56E59F07-19D2-4DCC-A69E-FA93690642FE
2026-09-07 02:02:33 - Error: hs.hotkey.bind: at least one of callbackPressed, callbackReleased, or callbackRepeat must be a function
2026-09-07 02:02:33 - JavaScript: after
```

`bind()` logs the error and returns `null` without throwing, so the surrounding
script keeps running.

## Changes
- Guard in `bind()` requiring ≥1 function callback.
- Updated the two `bindSpec` message tests to pass a callback (a message-only spec is now rejected under this rule).
- New tests: `bind` with no callbacks → `null`; `create` with no callbacks still succeeds.

## Notes
- Docs (`api.json` / HTML / TS) intentionally **not** regenerated here; the updated `bind()` docstring flags that a docs refresh is owed.
- If the current behaviour is by design, closing this PR is totally fine.
- Related: #208 (also touches `hs.hotkey`); minor rebase possible depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
