### PR TITLE
hs.hotkey: make released optional and unify callback handling

### DIFF
--- a/Hammerspoon 2/Modules/hs.hotkey/HSHotkey.swift
+++ b/Hammerspoon 2/Modules/hs.hotkey/HSHotkey.swift
@@ -151,7 +151,8 @@ import Carbon
     private var repeatIntervalTimer: Timer?
 
     init(keyCode: UInt32, modifiers: UInt32, mods: [String], key: String,
-         callbackPressed: JSFunction? = nil, callbackReleased: JSFunction? = nil) {
+         callbackPressed: JSFunction? = nil, callbackReleased: JSFunction? = nil,
+         callbackRepeat: JSFunction? = nil) {
         self.keyCode = keyCode
         self.modifiers = modifiers
         self.mods = mods
@@ -161,6 +162,7 @@ import Carbon
 
         self.callbackPressed = callbackPressed
         self.callbackReleased = callbackReleased
+        self.callbackRepeat = callbackRepeat
     }
 
     isolated deinit {

--- a/Hammerspoon 2/Modules/hs.hotkey/HSHotkeyModule.swift
+++ b/Hammerspoon 2/Modules/hs.hotkey/HSHotkeyModule.swift
@@ -18,7 +18,7 @@ import Carbon
     ///     `cmd` / `command` / `⌘`, `shift` / `⇧`, `alt` / `option` / `⌥`, `ctrl` / `control` / `⌃`.
     ///   - key: The key name or character (e.g., "a", "space", "return", "f1")
     ///   - callbackPressed: {(() => void) | null} A JavaScript function to call when the hotkey is pressed, or null for no callback
-    ///   - callbackReleased: {(() => void) | null} A JavaScript function to call when the hotkey is released, or null for no callback
+    ///   - callbackReleased?: {(() => void) | null} A JavaScript function to call when the hotkey is released, or null/omitted for no callback
     ///   - callbackRepeat?: {(() => void) | null} A JavaScript function to call repeatedly while the hotkey is held down, or null/omitted for no repeat
     /// - Returns: A hotkey object, or null if binding failed
     /// - Example:
@@ -51,7 +51,7 @@ import Carbon
     ///     `cmd` / `command` / `⌘`, `shift` / `⇧`, `alt` / `option` / `⌥`, `ctrl` / `control` / `⌃`.
     ///   - key: The key name or character (e.g., "a", "space", "return", "f1")
     ///   - callbackPressed: {(() => void) | null} A JavaScript function to call when the hotkey is pressed, or null for no callback
-    ///   - callbackReleased: {(() => void) | null} A JavaScript function to call when the hotkey is released, or null for no callback
+    ///   - callbackReleased?: {(() => void) | null} A JavaScript function to call when the hotkey is released, or null/omitted for no callback
     ///   - callbackRepeat?: {(() => void) | null} A JavaScript function to call repeatedly while the hotkey is held down, or null/omitted for no repeat
     /// - Returns: A hotkey object, or null if creation failed. Call `.enable()` to activate it.
     /// - Example:
@@ -212,8 +212,8 @@ import Carbon
             AKError("hs.hotkey.create: callbackPressed must be either a function or null")
             return nil
         }
-        guard callbackReleased.isFunction || callbackReleased.isNull else {
-            AKError("hs.hotkey.create: callbackReleased must be either a function or null")
+        guard callbackReleased.isFunction || callbackReleased.isNull || callbackReleased.isUndefined else {
+            AKError("hs.hotkey.create: callbackReleased must be either a function, null, or omitted")
             return nil
         }
         guard callbackRepeat.isFunction || callbackRepeat.isNull || callbackRepeat.isUndefined else {
@@ -226,12 +226,10 @@ import Carbon
             modifiers: modifierFlags,
             mods: mods,
             key: key,
-            callbackPressed: callbackPressed.isNull ? nil : callbackPressed,
-            callbackReleased: callbackReleased.isNull ? nil : callbackReleased
+            callbackPressed: callbackPressed.isFunction ? callbackPressed : nil,
+            callbackReleased: callbackReleased.isFunction ? callbackReleased : nil,
+            callbackRepeat: callbackRepeat.isFunction ? callbackRepeat : nil
         )
-        if callbackRepeat.isFunction {
-            hotkey.callbackRepeat = callbackRepeat
-        }
 
         activeHotkeys.add(hotkey)
         return hotkey

--- a/Hammerspoon 2Tests/IntegrationTests/HSHotkeyIntegrationTests.swift
+++ b/Hammerspoon 2Tests/IntegrationTests/HSHotkeyIntegrationTests.swift
@@ -260,6 +260,41 @@ struct HSHotkeyTests {
             #expect(!harness.hasException)
         }
 
+        @Test("bind without a released argument still binds (released is optional)")
+        func testBindWithoutReleasedArgumentBinds() {
+            let harness = makeHarness()
+            harness.eval("var hk = hs.hotkey.bind(['ctrl'], 'b', () => {})")
+            harness.expectTrue("typeof hk === 'object' && hk !== null")
+            harness.expectTrue("hk.isEnabled() === true")
+            #expect(!harness.hasException)
+        }
+
+        @Test("bind treats an omitted released the same as null (no released callback)")
+        func testBindOmittedReleasedIsUnset() {
+            let harness = makeHarness()
+            harness.eval("var hk = hs.hotkey.bind(['ctrl'], 'd', () => {})")
+            harness.expectTrue("hk.callbackReleased === null || hk.callbackReleased === undefined")
+            #expect(!harness.hasException)
+        }
+
+        @Test("bind without a pressed argument returns null (pressed is required)")
+        func testBindWithoutPressedReturnsNull() {
+            let harness = makeHarness()
+            harness.eval("var hk = hs.hotkey.bind(['ctrl'], 'l')")
+            harness.expectTrue("hk === null || hk === undefined")
+            #expect(!harness.hasException)
+        }
+
+        @Test("repeat-only hotkey (pressed and released null) sets callbackRepeat")
+        func testRepeatOnlyHotkeySetsRepeat() {
+            let harness = makeHarness()
+            harness.eval("var hk = hs.hotkey.bind(['ctrl'], 'm', null, null, () => {})")
+            harness.expectTrue("typeof hk === 'object' && hk !== null")
+            #expect(harness.evalTypeOf("hk.callbackRepeat") == "function")
+            harness.expectTrue("hk.callbackPressed === null || hk.callbackPressed === undefined")
+            #expect(!harness.hasException)
+        }
+
         @Test("triggering press/release with a repeat callback set does not throw")
         func testTriggerWithRepeatDoesNotThrow() {
             let harness = makeHarness()


### PR DESCRIPTION
## What
Three related cleanups to `hs.hotkey.bind()` / `create()`:

1. **`callbackReleased` is now optional** — `bind(mods, key, pressed)` works without an explicit `null`. `callbackPressed` stays required; `callbackRepeat` was already optional.
2. **Unified callback normalization** — all three callbacks go through `isFunction ? cb : nil` (whitelist) instead of `isNull ? nil : cb`. Robust to any input and avoids a spurious `JSCallback` "not a function" error log for `null`.
3. **Init symmetry** — `HSHotkey.init` gains a third optional `callbackRepeat` parameter, so all three are set in the initializer instead of `repeat` being assigned via a follow-up property write in `create()`.

## Why
- I saw that `repeatfn` was recently added as an optional parameter. The same can be done for `releasedfn`, which makes for a nicer API — no more trailing `, myFunction, null)` (once or twice) just to satisfy a required released slot.
- Porting Hammerspoon 1 configs (`bind(mods, key, fn)`) previously failed because released was required.
- The mixed `isNull ? nil :` / `if isFunction` idioms were inconsistent; the whitelist form is clearer and safer.
- The init asymmetry was a latent trap: `init` is `internal`, so a future caller could construct an `HSHotkey` and silently drop the repeat callback.

## Example
```js
// released + repeat may now be omitted; pressed is still required
hs.hotkey.bind(["cmd", "alt"], "h", () => console.log("pressed"))

// before, you had to pad the unused trailing slots:
hs.hotkey.bind(["cmd", "alt"], "h", () => console.log("pressed"), null)
```

## Changes
- `HSHotkey.init`: add optional `callbackRepeat`.
- `create()`: accept an omitted (`undefined`) `callbackReleased`; normalize all three with `isFunction ? cb : nil`; drop the follow-up `if callbackRepeat.isFunction`.
- Docstrings: `callbackReleased` marked optional.
- Tests: omitted released still binds; omitted released == no released; omitted pressed → `null`; repeat-only hotkey (`null, null, repeatFn`).

## Related
- Issue #196: Error: hs.hotkey.bind: callbackReleased must be either a function or null
- Pull Request #202: Rework hs.hotkey to support messages and repeats (by cmsj)

## Notes
- This softens the earlier "releasedfn is not optional" decision (commit `2ccec45`), so it may be intentional
- Docs (`api.json` / HTML / TS) intentionally **not** regenerated here; the updated docstrings flag that a refresh is owed.
- Touches the same `bind()` docstring block as #207, so whichever of the two lands second may need a trivial one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
